### PR TITLE
Implement generic record keeper based on IDictionary<T1, T2>

### DIFF
--- a/RecordKeepingApp.sln
+++ b/RecordKeepingApp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RecordKeepingApp", "RecordKeepingApp\RecordKeepingApp.csproj", "{43BEC8E6-0D8D-498F-9BA3-CF294D10B455}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{43BEC8E6-0D8D-498F-9BA3-CF294D10B455}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43BEC8E6-0D8D-498F-9BA3-CF294D10B455}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43BEC8E6-0D8D-498F-9BA3-CF294D10B455}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43BEC8E6-0D8D-498F-9BA3-CF294D10B455}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7387154A-D7A1-4CB8-B67E-20389A5C7A60}
+	EndGlobalSection
+EndGlobal

--- a/RecordKeepingApp/Library/IRecordKeeper.cs
+++ b/RecordKeepingApp/Library/IRecordKeeper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RecordKeepingApp.Library
+{
+    interface IRecordKeeper<T1, T2>
+    {
+
+        void AcceptItem(T1 key, T2 value);
+
+
+        T2 FetchOne(T1 key);
+
+
+        List<T2> FetchAll();
+
+
+        int Count { get; }
+    }
+}

--- a/RecordKeepingApp/Library/MobilePhone.cs
+++ b/RecordKeepingApp/Library/MobilePhone.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RecordKeepingApp.Library
+{
+    class MobilePhone
+    {
+
+
+    }
+}

--- a/RecordKeepingApp/Library/RecordKeeper.cs
+++ b/RecordKeepingApp/Library/RecordKeeper.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RecordKeepingApp.Library
+{
+    class RecordKeeper<T1, T2> : IRecordKeeper<T1, T2>
+    {
+        private readonly Dictionary<T1, T2> _dataStore; 
+
+
+        public RecordKeeper()
+        {
+            _dataStore = new Dictionary<T1, T2>();
+        }
+
+
+        public int Count 
+        {
+            get => _dataStore.Count;
+        }
+
+
+        public void AcceptItem(T1 key, T2 value)
+        {
+            _dataStore.Add(key, value);
+        }
+
+
+        public List<T2> FetchAll()
+        {
+            return new List<T2>(_dataStore.Values);
+        }
+
+
+        public T2 FetchOne(T1 key)
+        {
+           return _dataStore[key];
+        }
+
+
+        public bool FetchOne(T1 key, out T2 result)
+        {
+            return _dataStore.TryGetValue(key, out result);
+        }
+    }
+}

--- a/RecordKeepingApp/Program.cs
+++ b/RecordKeepingApp/Program.cs
@@ -1,0 +1,47 @@
+﻿using RecordKeepingApp.Library;
+using System;
+
+namespace RecordKeepingApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+
+            // A college lecturer needs to keep track of class attendance. 
+            // Each record contains a matric number along with a true (present) or false(absent) value.
+
+            // Create an attendance register that meets the lecturer's data storage needs
+            IRecordKeeper<string, bool> attendanceRegister = new RecordKeeper<string, bool>();
+
+            // Populate the attendance register
+            attendanceRegister.AcceptItem("UNILAG/1001", true);
+            attendanceRegister.AcceptItem("UNILAG/1002", true);
+            attendanceRegister.AcceptItem("UNILAG/1003", false);
+            attendanceRegister.AcceptItem("UNILAG/1004", true);
+
+            // A receptionist needs to maintain a register of visitors to the organization. 
+            // Each record contains a timestamp (arrival time) along with the visitor’s name. 
+
+            // Create a visitors register that meets the receptionist's data storage needs
+            IRecordKeeper<DateTime, string> visitorRegister = new RecordKeeper<DateTime, string>();
+
+            // Populate the attendance register
+            visitorRegister.AcceptItem(DateTime.Now, "Mr. Tunde Bello");
+            visitorRegister.AcceptItem(DateTime.Now, "Mr. Phil Newman");
+            visitorRegister.AcceptItem(DateTime.Now, "Mr. Boyowa Odometa");
+
+
+            // A mobile phone dealer needs to keep an inventory of phones in stock. 
+            // Each record contains a unique serial number and the phone itself.   
+
+            // Create an inventory that meets the mobile phone dealer's data storage needs
+            IRecordKeeper<string, MobilePhone> inventory = new RecordKeeper<string, MobilePhone>();
+
+            // Populate the inventory
+            inventory.AcceptItem("MP10028299", new MobilePhone());
+            inventory.AcceptItem("MP10028347", new MobilePhone());
+            inventory.AcceptItem("MP10028210", new MobilePhone());
+        }
+    }
+}

--- a/RecordKeepingApp/RecordKeepingApp.csproj
+++ b/RecordKeepingApp/RecordKeepingApp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
### What does this PR do?

This PR contains the first version of the recordkeeping app. 
- It defines a generic interface and a generic class that use two type parameters `T1` and `T2`. 
- The implementation uses a `Dictionary<T1,T2>` as the datastore internally, and exposes several public methods as well as a public property.  